### PR TITLE
Align IPv6 flag comparison in Telegram summary

### DIFF
--- a/scripts/init.rsc
+++ b/scripts/init.rsc
@@ -575,7 +575,7 @@
 
 /:global tg_text ("[部署完成]\n"
   . "LAN: " . $lanSubnet . "\n"
-  . ($enableIPv6 = "yes" ? ("LANv6: " . $lanSubnetV6 . "\n") : "")
+  . ($enableIPv6 = yes ? ("LANv6: " . $lanSubnetV6 . "\n") : "")
   . "SSH(路由器): " . $sshPort . "（需端口敲门）\n"
   . "SSH映射: " . $mappedSSHPort . " -> " . $mappedSSHTarget . ":22\n"
   . "WinBox: " . $winboxPort . "\n"


### PR DESCRIPTION
## Summary
- align the IPv6 enablement check in the deployment completion Telegram message with the boolean style used elsewhere

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e133e2842c83299b60613fc511686d