### PR TITLE
Handle GeoIP update failures by disabling raw rule

### DIFF
--- a/scripts/init.rsc
+++ b/scripts/init.rsc
@@ -271,6 +271,19 @@
             /ip firewall raw set $geoRule disabled=no
             :log info "  - GeoIP RAW 规则已启用"
         }
+    } else={
+        :local geoRule [/ip firewall raw find where comment="RAW: GeoIP drop"]
+        :if ($geoRule != "") do={
+            :local isDisabled [/ip firewall raw get $geoRule disabled]
+            :if ($isDisabled = false || $isDisabled = "no") do={
+                /ip firewall raw set $geoRule disabled=yes
+                :log warning "  - GeoIP RAW 规则已暂时禁用（本次同步失败）"
+            } else={
+                :log warning "  - GeoIP RAW 规则保持禁用状态（本次同步失败）"
+            }
+        } else={
+            :log warning "  - 未找到 GeoIP RAW 规则，本次同步失败"
+        }
     }
 
     # 投递到话题群


### PR DESCRIPTION
## Summary
- add a failure branch to geoip_update that temporarily disables the GeoIP raw rule when no entries are imported
- log whether the rule is disabled or already disabled when the sync fails

## Testing
- not run (manual RouterOS execution required)

------
https://chatgpt.com/codex/tasks/task_e_68e13b7d3fcc83298fd990b54dc9d58a